### PR TITLE
Modify API for updating a running deployment 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Requirements
 Flask==1.1.2 
 Flask-Cors==3.0.7 
 Flask-RESTful==0.3.7 

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,10 +45,10 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.7 
 pycparser==2.20
 pynacl==1.4.0 
-pyrsistent==0.14.11 
-pytest==4.3.0 
-pytest-cov==2.7.1 
-pytest-mock==1.10.4 
+pyrsistent==0.14.11
+pytest==4.3.0
+pytest-cov==2.7.1
+pytest-mock==1.10.4
 python-dateutil==2.8.1 
 pytz==2021.1 
 requests==2.20.1 

--- a/tycho/actions.py
+++ b/tycho/actions.py
@@ -139,7 +139,6 @@ class ModifySystemResource(TychoResource):
     """ Modify a system given a name, labels, resources(cpu and memory) """
 
     def post(self, request):
-        response = {}
         try:
             logging.debug(f"System specs to modify: {request}")
             system_modify = tycho().parse_modify(request)

--- a/tycho/actions.py
+++ b/tycho/actions.py
@@ -67,7 +67,6 @@ class TychoResource:
             result = {
                 'error': message
             }
-            print(json.dumps(result, indent=2))
         return {
             'status': status,
             'result': result,

--- a/tycho/actions.py
+++ b/tycho/actions.py
@@ -18,6 +18,7 @@ containers running on abstracted compute fabrics.
  
 """
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 """ Load the schema. """
 schema_file_path = os.path.join (
@@ -132,4 +133,22 @@ class StatusSystemResource(TychoResource):
                 exception=e,
                 message=f"Failed to get system status.")
         print(json.dumps(response, indent=2))
+        return response
+
+
+class ModifySystemResource(TychoResource):
+    """ Modify a system given a name, labels, resources(cpu and memory) """
+
+    def post(self, request):
+        response = {}
+        try:
+            logging.debug(f"System specs to modify: {request}")
+            system_modify = tycho().parse_modify(request)
+            response = self.create_response(
+                result=tycho().get_compute().modify(system_modify),
+                message=f"Modified the system")
+        except Exception as e:
+            response = self.create_response(
+                exception=e,
+                message=f"Failed to modify system status.")
         return response

--- a/tycho/client.py
+++ b/tycho/client.py
@@ -16,7 +16,6 @@ from tycho.actions import StartSystemResource, StatusSystemResource, DeleteSyste
 from kubernetes import client as k8s_client, config as k8s_config
 
 logger = logging.getLogger (__name__)
-logger.setLevel(logging.DEBUG)
 
 mem_converter = {
     'M' : lambda v : v * 10 ** 6,
@@ -126,7 +125,6 @@ class TychoClient:
             logger.debug (json.dumps(result, indent=2))
         else:
             result = self.actions.get(service).post(request)
-            print(f"=====================")
             logger.debug(f"{result} received from service: {service}")
         return result
     
@@ -211,7 +209,7 @@ class TychoClient:
             :type request: JSON
         """
         response = self.request("modify", request)
-        return {}
+        return response
 
     def up (self, name, system, settings=""):
         """ Bring a service up starting with a docker-compose spec. 
@@ -333,8 +331,9 @@ class TychoClient:
         try:
             response = self.modify(mod_items)
             logger.debug(json.dumps(response, indent=2))
+            return response
         except (AttributeError, Exception) as e:
-            logger.exception("Error in modifying system.")
+            logger.exception(f"Error in modifying system. {e}")
 
             
 class TychoClientFactory:

--- a/tycho/client.py
+++ b/tycho/client.py
@@ -197,16 +197,18 @@ class TychoClient:
         return TychoStatus (**response)
 
     def modify(self, request):
-        """ Modify a running systems.
+        """ Takes in a JSON formatted metadata and specs of a running system.
 
-            Modify metadata, few specifications of a running system.
+            Some examples for a request,
+            * {"tycho-guid": <guid>, "labels": {"name": <any-name>}, "resources": {"cpu": <cpu>, "memory": <memory>}}
+            * {"tycho-guid": <guid>, "labels": {"name": "<any-name>"}}
+            * {"tycho-guid": <guid>, "resources": {"cpu": <cpu>, "memory": <memory>}}
 
-            The format of a request is::
+            :param request: Request formatted as above
+            :type request: json
 
-                {"labels": {"name": "any-name"}, "resources": {"cpu": "1", "memory": "250M"}}
-
-            :param request: Request formatted as above.
-            :type request: JSON
+            :returns: A list of all the patches applied to the system
+            :rtype: A list
         """
         response = self.request("modify", request)
         return response
@@ -321,11 +323,23 @@ class TychoClient:
             traceback.print_exc (e)
 
     def patch(self, mod_items):
-        """ Modify a system.
+        """
+            Modify a running system.
+            Takes in a JSON formatted metadata and specs of a running system.
 
-            CLI endpoint for modifying running systems.::
+            Some examples for a request,
+            * {"tycho-guid": <guid>, "labels": {"name": <any-name>}, "resources": {"cpu": <cpu>, "memory": <memory>}}
+            * {"tycho-guid": <guid>, "labels": {"name": "<any-name>"}}
+            * {"tycho-guid": <guid>, "resources": {"cpu": <cpu>, "memory": <memory>}}
 
-                tycho modify <GUID>
+            CLI endpoint for modifying running systems::
+                python client -m <JSON object>
+
+            :param mod_items: Request formatted as above
+            :type mod_items: json
+
+            :returns: A list of all the patches applied to the system
+            :rtype: A list
         """
         logger.info(f"System specifications and metadata to be modified: {mod_items}")
         try:

--- a/tycho/context.py
+++ b/tycho/context.py
@@ -180,6 +180,9 @@ class TychoContext:
 
     def delete (self, request):
         return self.client.delete (request)
+
+    def update(self, request):
+        return self.client.patch(request)
     
     def start (self, principal, app_id, resource_request):
         """ Get application metadata, docker-compose structure, settings, and compose API request. """

--- a/tycho/core.py
+++ b/tycho/core.py
@@ -1,7 +1,7 @@
 from tycho.config import Config
 from tycho.factory import ComputeFactory
 from tycho.factory import supported_backplanes
-from tycho.model import System
+from tycho.model import System, ModifySystem
 
 class Tycho: 
     """ An organizing abstraction for the Tycho system. 
@@ -55,7 +55,24 @@ class Tycho:
             serviceAccount=request.get('serviceaccount', 'default'),
             env=request.get ('env', {}),
             services=request.get ('services', {}))
-    
+
+    def parse_modify(self, request):
+        """ Parse a request to construct an abstract syntax tree for a system.
+
+            :param request: JSON object formatted to contain name, structure, env, and
+                            service elements. Name is a string. Structue is the JSON
+                            object resulting from loading a docker-compose.yaml. Env
+                            is a JSON dictionary mapping environment variables to
+                            values. These will be substituted into the specification.
+                            Services is a JSON object representing which containers and
+                            ports to expose, and other networking rules.
+            :returns: `.System`
+        """
+        return ModifySystem.parse_modify(
+            name=request['name'],
+            labels=request.get('labels', {}),
+            resources=request.get('resources', {}))
+
     @staticmethod
     def is_valid_backplane (backplane):
         """ Determine if the argument is a valid backplane. """

--- a/tycho/core.py
+++ b/tycho/core.py
@@ -70,7 +70,7 @@ class Tycho:
         """
         return ModifySystem.parse_modify(
             config=self.config,
-            name=request.get("app", None),
+            guid=request.get("tycho-guid", None),
             labels=request.get('labels', {}),
             resources=request.get('resources', {}))
 

--- a/tycho/core.py
+++ b/tycho/core.py
@@ -69,7 +69,8 @@ class Tycho:
             :returns: `.System`
         """
         return ModifySystem.parse_modify(
-            name=request['name'],
+            config=self.config,
+            name=request.get("app", None),
             labels=request.get('labels', {}),
             resources=request.get('resources', {}))
 

--- a/tycho/core.py
+++ b/tycho/core.py
@@ -38,8 +38,8 @@ class Tycho:
     def parse (self, request):
         """ Parse a request to construct an abstract syntax tree for a system.
         
-            :param request: JSON object formatted to contain name, structure, env, and 
-                            service elements. Name is a string. Structue is the JSON 
+            :param request: JSON object formatted to contain name, structure, env, and
+                            service elements. Name is a string. Structue is the JSON
                             object resulting from loading a docker-compose.yaml. Env
                             is a JSON dictionary mapping environment variables to
                             values. These will be substituted into the specification.
@@ -57,16 +57,14 @@ class Tycho:
             services=request.get ('services', {}))
 
     def parse_modify(self, request):
-        """ Parse a request to construct an abstract syntax tree for a system.
+        """ Parse a request into a class representation of metadata and specs of a system to be modified.
 
-            :param request: JSON object formatted to contain name, structure, env, and
-                            service elements. Name is a string. Structue is the JSON
-                            object resulting from loading a docker-compose.yaml. Env
-                            is a JSON dictionary mapping environment variables to
-                            values. These will be substituted into the specification.
-                            Services is a JSON object representing which containers and
-                            ports to expose, and other networking rules.
-            :returns: `.System`
+            :param request: JSON object formatted to contain guid, labels, resources.
+                            GUID is a hexadecimal string of UUID representing a system.
+                            Labels is a dictionary of label and label-name as key-value pairs.
+                            Resources is a dictionary of cpu and memory keys, with corresponding values.
+                            Can optionally pass a config.
+            :returns: An instance of `tycho.model.ModifySystem`
         """
         return ModifySystem.parse_modify(
             config=self.config,

--- a/tycho/core.py
+++ b/tycho/core.py
@@ -69,8 +69,9 @@ class Tycho:
         return ModifySystem.parse_modify(
             config=self.config,
             guid=request.get("tycho-guid", None),
-            labels=request.get('labels', {}),
-            resources=request.get('resources', {}))
+            labels=request.get("labels", {}),
+            cpu=request.get("cpu", None),
+            memory=request.get("memory", None))
 
     @staticmethod
     def is_valid_backplane (backplane):

--- a/tycho/exceptions.py
+++ b/tycho/exceptions.py
@@ -3,12 +3,22 @@ class TychoException(Exception):
         super().__init__(message)
         self.details = details
 
+
 class StartException(Exception):
     def __init__(self, message, details=""):
         super().__init__(message, details)
+
+
 class DeleteException(Exception):
     def __init__(self, message, details=""):
         super().__init__(message, details)
+
+
 class ContextException(TychoException):
+    def __init__(self, message, details=""):
+        super().__init__(message, details)
+
+
+class ModifyException(Exception):
     def __init__(self, message, details=""):
         super().__init__(message, details)

--- a/tycho/json/modify1.json
+++ b/tycho/json/modify1.json
@@ -1,1 +1,1 @@
-{"app": "nginx", "labels": {"name": "sample-name"}, "resources": {"cpu": "1", "memory": "250M"}}
+{"tycho-guid": "4e5aa1808da44534aa711292debda59e", "labels": {"name": "sample-name"}, "resources": {"cpu": "1", "memory": "250M"}}

--- a/tycho/json/modify1.json
+++ b/tycho/json/modify1.json
@@ -1,1 +1,1 @@
-{"tycho-guid": "4e5aa1808da44534aa711292debda59e", "labels": {"name": "sample-name"}, "resources": {"cpu": "1", "memory": "250M"}}
+{"tycho-guid": "4e5aa1808da44534aa711292debda59e", "labels": {"name": "sample-name"}, "cpu": "1", "memory": "250M"}

--- a/tycho/json/modify1.json
+++ b/tycho/json/modify1.json
@@ -1,0 +1,1 @@
+{"app": "nginx", "labels": {"name": "sample-name"}, "resources": {"cpu": "1", "memory": "250M"}}

--- a/tycho/json/modify2.json
+++ b/tycho/json/modify2.json
@@ -1,1 +1,1 @@
-{"app": "nginx", "labels": {"name": "sample-name"}}
+{"tycho-guid": "4e5aa1808da44534aa711292debda59e", "labels": {"name": "sample-name"}}

--- a/tycho/json/modify2.json
+++ b/tycho/json/modify2.json
@@ -1,0 +1,1 @@
+{"app": "nginx", "labels": {"name": "sample-name"}}

--- a/tycho/json/modify3.json
+++ b/tycho/json/modify3.json
@@ -1,1 +1,1 @@
-{"tycho-guid": "4e5aa1808da44534aa711292debda59e", "resources": {"cpu": "1", "memory": "250M"}}
+{"tycho-guid": "4e5aa1808da44534aa711292debda59e", "cpu": "1", "memory": "250M"}

--- a/tycho/json/modify3.json
+++ b/tycho/json/modify3.json
@@ -1,1 +1,1 @@
-{"app": "nginx", "resources": {"cpu": "1", "memory": "250M"}}
+{"tycho-guid": "4e5aa1808da44534aa711292debda59e", "resources": {"cpu": "1", "memory": "250M"}}

--- a/tycho/json/modify3.json
+++ b/tycho/json/modify3.json
@@ -1,0 +1,1 @@
+{"app": "nginx", "resources": {"cpu": "1", "memory": "250M"}}

--- a/tycho/kube.py
+++ b/tycho/kube.py
@@ -447,14 +447,26 @@ class KubernetesCompute(Compute):
         return result
 
     def modify(self, system_modify):
-        """ Modify system.
-            Takes in a system_modify object containing,
-            1) name --> GUID
-            2) labels --> dict of labels
-            3) resources --> dict consisting of cpu and memory
+        """
+           Returns a list of all patches,
 
-            :param system_modify: Spec and Metadata object.
-            :type name: ModifySystem
+               * metadata labels - Applied to each deployment resource including the pods managed by it.
+               * container resources - Are applied to each container in the pod managed by a deployment.
+
+           Takes in a handle :class:`tycho.model.ModifySystem` with the following instance variables,
+
+               * config - A default config for Tycho.
+               * guid - A unique guid to a system/deployment.
+               * labels - A dictionary of labels.
+               * resources - A dictionary containing cpu and memory as keys.
+               * containers - A list of containers the resources are applied to.
+
+           :param system_modify: Spec and Metadata object
+           :type system_modify: class ModifySystem
+
+           :returns: A list of patches applied
+           :rtype: A list
+
         """
         namespace = self.namespace
         patches_applied = list()

--- a/tycho/kube.py
+++ b/tycho/kube.py
@@ -491,11 +491,6 @@ class KubernetesCompute(Compute):
                 patch_template = templates[0] if len(templates) > 0 else {}
                 patches_applied.append(patch_template)
 
-                if len(patch_template) == 0:
-                    raise Exception("Invalid arguments. Need at least one of resources or labels to modify. \n"
-                                    "Format: 'labels': {'test-label-name': <test-label-value>, 'name': <name>}, "
-                                    "'resources': {'cpu': <cpu>, 'memory': <memory>}")
-
                 _ = self.extensions_api.patch_namespaced_deployment(
                         name=deployment.metadata.name,
                         namespace=namespace,

--- a/tycho/kube.py
+++ b/tycho/kube.py
@@ -323,9 +323,7 @@ class KubernetesCompute(Compute):
         
         """ Instantiate the deployment object """
         logger.debug (f"creating deployment specification {template}")
-#        deployment = k8s_client.ExtensionsV1beta1Deployment(
         deployment = k8s_client.V1Deployment(
-#           api_version="extensions/v1beta1",
             api_version="apps/v1",
             kind="Deployment",
             metadata=k8s_client.V1ObjectMeta(

--- a/tycho/model.py
+++ b/tycho/model.py
@@ -307,7 +307,24 @@ class System:
 
 
 class ModifySystem:
+    """
+       This is a class representation of a system's metadata and specs that needs to be modified.
+
+       :param config: A default config for Tycho
+       :type config: A dict
+       :param guid: A unique guid to a system/deployment
+       :type guid: The UUID as a 32-character hexadecimal string
+       :param labels: A dictionary of labels that are applied to deployments
+       :type labels: A dictionary
+       :param resources: A dictionary containing cpu and memory as keys
+       :type resources: A dictionary
+       :param containers: A list of containers that are applied to resources
+       :type containers: A list of Kubernetes V1Container objects, optional
+    """
     def __init__(self, config, guid, labels, resources):
+        """
+           A constructor method to ModifySystem
+        """
         self.config = config
         self.guid = guid
         self.labels = labels
@@ -316,6 +333,12 @@ class ModifySystem:
 
     @staticmethod
     def parse_modify(config, guid, labels, resources):
+        """
+           Returns an instance of :class:`tycho.model.ModifySystem` class
+
+           :returns: An instance of ModifySystem class
+           :rtype: A class object
+        """
         modify_system = ModifySystem(
             config,
             guid,

--- a/tycho/model.py
+++ b/tycho/model.py
@@ -307,24 +307,26 @@ class System:
 
 
 class ModifySystem:
-    def __init__(self, config, name, labels, resources):
+    def __init__(self, config, guid, labels, resources):
         self.config = config
-        self.name = name
+        self.guid = guid
         self.labels = labels
         self.resources = resources
+        self.containers = []
 
     @staticmethod
-    def parse_modify(config, name, labels, resources):
+    def parse_modify(config, guid, labels, resources):
         modify_system = ModifySystem(
             config,
-            name,
+            guid,
             labels,
             resources
         )
         return modify_system
 
     def __repr__(self):
-        return f"name: {self.name} labels: {self.labels} resources: {self.resources}"
+        return f"name: {self.guid} labels: {self.labels} resources: {self.resources}"
+
 
 class Service:
     """ Model network connectivity rules to the system. """

--- a/tycho/model.py
+++ b/tycho/model.py
@@ -10,6 +10,7 @@ from tycho.tycho_utils import TemplateUtils
 
 logger = logging.getLogger (__name__)
 
+
 class Limits:
     """ Abstraction of resource limits on a container in a system. """
     def __init__(self,
@@ -31,6 +32,7 @@ class Limits:
         self.memory = memory
     def __repr__(self):
         return f"cpus:{self.cpus} gpus:{self.gpus} mem:{self.memory}"
+
 
 class Volumes:
     def __init__(self, id, containers):
@@ -57,6 +59,7 @@ class Volumes:
                    logger.debug(f"Volume definition should follow the pattern: pvc://<pvc_name>/<sub-path>:<container-path> or pvc://<sub-path>:<container-path>")
                    raise Exception(f"Wrong Volume definition in Container:{container['name']} and Volume:{volume}")
        return self.volumes
+
 
 class Container:
     """ Invocation of an image in a specific infastructural context. """
@@ -112,6 +115,7 @@ class Container:
 
     def __repr__(self):
         return f"name:{self.name} image:{self.image} id:{self.identity} limits:{self.limits}"
+
 
 class System:
     """ Distributed system of interacting containerized software. """
@@ -300,6 +304,25 @@ class System:
 
     def __repr__(self):
         return f"name:{self.name} containers:{self.containers}"
+
+
+class ModifySystem:
+    def __init__(self, name, labels, resources):
+        self.name = name
+        self.labels = labels
+        self.resources = resources
+
+    @staticmethod
+    def parse_modify(name, labels, resources):
+        modify_system = ModifySystem(
+            name,
+            labels,
+            resources
+        )
+        return modify_system
+
+    def __repr__(self):
+        return f"name: {self.name} labels: {self.labels} resources: {self.resources}"
 
 class Service:
     """ Model network connectivity rules to the system. """

--- a/tycho/model.py
+++ b/tycho/model.py
@@ -307,14 +307,16 @@ class System:
 
 
 class ModifySystem:
-    def __init__(self, name, labels, resources):
+    def __init__(self, config, name, labels, resources):
+        self.config = config
         self.name = name
         self.labels = labels
         self.resources = resources
 
     @staticmethod
-    def parse_modify(name, labels, resources):
+    def parse_modify(config, name, labels, resources):
         modify_system = ModifySystem(
+            config,
             name,
             labels,
             resources

--- a/tycho/model.py
+++ b/tycho/model.py
@@ -321,29 +321,43 @@ class ModifySystem:
        :param containers: A list of containers that are applied to resources
        :type containers: A list of Kubernetes V1Container objects, optional
     """
-    def __init__(self, config, guid, labels, resources):
+    def __init__(self, config, patch, guid, labels, resources):
         """
            A constructor method to ModifySystem
         """
         self.config = config
+        self.patch = patch
         self.guid = guid
         self.labels = labels
         self.resources = resources
         self.containers = []
 
     @staticmethod
-    def parse_modify(config, guid, labels, resources):
+    def parse_modify(config, guid, labels, cpu, memory):
         """
            Returns an instance of :class:`tycho.model.ModifySystem` class
 
            :returns: An instance of ModifySystem class
            :rtype: A class object
         """
+
+        resources = {}
+        if cpu is not None:
+            resources.update({"cpu": cpu})
+        if memory is not None:
+            resources.update({"memory": memory})
+
+        if len(resources) > 0 or len(labels) > 0:
+            patch = True
+        else:
+            patch = False
+
         modify_system = ModifySystem(
             config,
+            patch,
             guid,
             labels,
-            resources
+            resources,
         )
         return modify_system
 

--- a/tycho/sample/json/modify.json
+++ b/tycho/sample/json/modify.json
@@ -1,0 +1,9 @@
+{
+	"labels": {
+		"name": "sample-name"
+	},
+	"resources": {
+		"cpu": "1",
+		"memory": "250M"
+	}
+}

--- a/tycho/sample/json/modify.json
+++ b/tycho/sample/json/modify.json
@@ -1,9 +1,0 @@
-{
-	"labels": {
-		"name": "sample-name"
-	},
-	"resources": {
-		"cpu": "1",
-		"memory": "250M"
-	}
-}

--- a/tycho/template/patch.yaml
+++ b/tycho/template/patch.yaml
@@ -11,6 +11,7 @@ spec:
     {% if system_modify.resources|length > 0 %}
     spec:
       containers:
+      {% for container in system_modify.containers %}
       - resources:
           limits:
           {% for key, value in system_modify.resources.items() %}
@@ -20,7 +21,8 @@ spec:
           {% for key, value in system_modify.resources.items() %}
             {{ key }}: {{ value }}
           {% endfor %}
-        name: nginx
-        image: nginx:1.14.2
+        name: {{ container.name }}
+        image: {{ container.image }}
+      {% endfor %}
     {% endif %}
 {% endif %}

--- a/tycho/template/patch.yaml
+++ b/tycho/template/patch.yaml
@@ -1,0 +1,26 @@
+{% if (not system_modify.lables|length > 0) or (not system_modify.resources|length != 0) %}
+spec:
+  template:
+    {% if system_modify.labels|length > 0 %}
+    metadata:
+      labels:
+    {% for key, value in system_modify.labels.items() %}
+        {{ key }}: {{ value }}
+    {% endfor %}
+    {% endif %}
+    {% if system_modify.resources|length > 0 %}
+    spec:
+      containers:
+      - resources:
+          limits:
+          {% for key, value in system_modify.resources.items() %}
+            {{ key }}: {{ value }}
+          {% endfor %}
+          requests:
+          {% for key, value in system_modify.resources.items() %}
+            {{ key }}: {{ value }}
+          {% endfor %}
+        name: nginx
+        image: nginx:1.14.2
+    {% endif %}
+{% endif %}

--- a/tycho/template/patch.yaml
+++ b/tycho/template/patch.yaml
@@ -1,4 +1,4 @@
-{% if (not system_modify.lables|length > 0) or (not system_modify.resources|length != 0) %}
+{% if system_modify.patch %}
 spec:
   template:
     {% if system_modify.labels|length > 0 %}

--- a/tycho/test/conftest.py
+++ b/tycho/test/conftest.py
@@ -10,8 +10,6 @@ from tycho.test.lib import system_request
 modify_data_path = os.path.dirname(os.path.abspath(__file__))
 modify_data_abs_path = os.path.join(modify_data_path, "..", "json")
 
-print(modify_data_abs_path)
-
 
 @pytest.fixture(params=["data1", "data2"])
 def volume_model_data(request):
@@ -49,7 +47,7 @@ def volume_model_data(request):
 
 @pytest.fixture
 def mock_modify_function_env_variables(mocker):
-    mocker.patch.dict("os.environ", {"NAMESPACE": "muralikarthik-k"})
+    mocker.patch.dict("os.environ", {"NAMESPACE": os.environ.get("NAMESPACE", "default")})
     yield
 
 

--- a/tycho/test/conftest.py
+++ b/tycho/test/conftest.py
@@ -1,8 +1,17 @@
+import os
+import json
 import logging
 import pytest
+from pathlib import Path
 from tycho.test.lib import client
 from tycho.test.lib import system_request
 # https://medium.com/@yeraydiazdiaz/what-the-mock-cheatsheet-mocking-in-python-6a71db997832
+
+modify_data_path = os.path.dirname(os.path.abspath(__file__))
+modify_data_abs_path = os.path.join(modify_data_path, "..", "json")
+
+print(modify_data_abs_path)
+
 
 @pytest.fixture(params=["data1", "data2"])
 def volume_model_data(request):
@@ -36,3 +45,24 @@ def volume_model_data(request):
              }
         ]
         return data
+
+
+@pytest.fixture
+def mock_modify_function_env_variables(mocker):
+    mocker.patch.dict("os.environ", {"NAMESPACE": "muralikarthik-k"})
+    yield
+
+
+def get_data_for_modify_function():
+    data_list = []
+    files = Path(modify_data_abs_path).glob("*.json")
+    for file in files:
+        with open(file) as data_file:
+            data_list.append(data_file.read())
+    return data_list
+
+
+@pytest.fixture(params=get_data_for_modify_function())
+def modify_data(request):
+    data = json.loads(request.param)
+    yield data

--- a/tycho/test/modify/templates/deploy.yaml
+++ b/tycho/test/modify/templates/deploy.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    executor: tycho
+    tycho-guid: 4e5aa1808da44534aa711292debda59e
+    username: test-user
+  name: jupyter-ds-4e5aa1808da44534aa711292debda59e
+  namespace: <name-space>
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      tycho-guid: 4e5aa1808da44534aa711292debda59e
+      username: test-user
+  template:
+    metadata:
+      labels:
+        app-name: jupyter-ds
+        executor: tycho
+        name: sample-name
+        tycho-app-id: ""
+        tycho-guid: 4e5aa1808da44534aa711292debda59e
+        username: test-user
+      name: jupyter-ds-4e5aa1808da44534aa711292debda59e
+    spec:
+      containers:
+      - image: nginx:1.14.2
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
+          requests:
+            cpu: "1"
+            memory: 250Mi
+      - command:
+        - /bin/bash
+        - -c
+        - start.sh jupyter lab --LabApp.token= --ip="*" --NotebookApp.base_url=${NB_PREFIX}
+          --NotebookApp.allow_origin="*"
+        env:
+        - name: HOST_PORT
+          value: "8888"
+        - name: GUID
+          value: 4e5aa1808da44534aa711292debda59e
+        - name: USER_NAME
+          value: test-user
+        - name: NB_PREFIX
+          value: /
+        image: heliumdatastage/jupyter-datascience:v0.0.3
+        imagePullPolicy: IfNotPresent
+        name: jupyter-ds
+        resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
+            nvidia.com/gpu: "0"
+          requests:
+            cpu: "1"
+            memory: 250Mi
+            nvidia.com/gpu: "0"
+

--- a/tycho/test/test_model_volume.py
+++ b/tycho/test/test_model_volume.py
@@ -2,6 +2,7 @@ import pytest
 import sys
 from tycho.model import Volumes
 
+
 # Sample data from conftest.py
 @pytest.mark.parametrize('volume_model_data', ['data1'], indirect=True)
 def test_model_volume(volume_model_data):

--- a/tycho/test/test_modify.py
+++ b/tycho/test/test_modify.py
@@ -7,7 +7,7 @@ from pytest import fixture
 from tycho.client import TychoClient
 
 
-#@mark.skip(reason="Need connection to a running Kubernetes cluster.")
+@mark.skip(reason="Need connection to a running Kubernetes cluster and a valid guid.")
 @mark.kubernetes
 class TestModify:
 

--- a/tycho/test/test_modify.py
+++ b/tycho/test/test_modify.py
@@ -6,7 +6,8 @@ from pytest import fixture
 
 from tycho.client import TychoClient
 
-@mark.skip
+
+#@mark.skip(reason="Need connection to a running Kubernetes cluster.")
 @mark.kubernetes
 class TestModify:
 

--- a/tycho/test/test_modify.py
+++ b/tycho/test/test_modify.py
@@ -1,0 +1,19 @@
+import os
+import json
+
+from pytest import mark
+from pytest import fixture
+
+from tycho.client import TychoClient
+
+@mark.skip
+@mark.kubernetes
+class TestModify:
+
+    def test_modify_functional(self, modify_data, mock_modify_function_env_variables):
+        client = TychoClient()
+        response = client.patch(modify_data)
+        if response["status"] == "success":
+            assert True
+        else:
+            assert False


### PR DESCRIPTION
Modify API takes labels(dict), cpu and memory(can be either one of these or all) and returns the patches that have been applied to a deployment which then propagates to the pods managed by it (scheduling a new pod by terminating the existing one).