### PR TITLE
SAS under restartr context

### DIFF
--- a/tycho/client.py
+++ b/tycho/client.py
@@ -30,7 +30,7 @@ class TychoService:
     """ Represent a service endpoint. """
     try_minikube = True
 
-    def __init__(self, name, app_id, ip_address, port, sid=None, creation_time=None, utilization={}):
+    def __init__(self, name, app_id, ip_address, port, sid=None, creation_time=None, utilization={}, conn_string=""):
         self.name = name
         self.app_id = app_id
         self.ip_address = ip_address
@@ -39,6 +39,7 @@ class TychoService:
         self.creation_time = creation_time
         self.utilization = utilization
         self.total_util = self.get_utilization (utilization)
+        self.conn_string = conn_string
             
     def get_utilization (self, utilization):
         total = {
@@ -89,6 +90,7 @@ class TychoSystem:
             TychoService(name=k, app_id=result['name'], ip_address=v['ip_address'], port=v['port-1'])
             for k, v in result['containers'].items ()
         ]
+        self.conn_string = result['conn_string']
         self.message = message
 
         

--- a/tycho/conf/app-registry.yaml
+++ b/tycho/conf/app-registry.yaml
@@ -221,6 +221,8 @@ contexts:
   restartr:
     extends:
       - common
+    sas-studio:
+      conn_string: "SASStudio"
     apps:
       blackbalsam-clinical:
         name: Blackbalsam Clinical
@@ -230,6 +232,14 @@ contexts:
         serviceAccount: spark
         services:
           blackbalsam-clinical : 8888
+      sas-studio:
+        name: SAS Studio
+        description: Jump-start your data and analytics efforts with an interactive development environment.
+        details: SAS (previously "Statistical Analysis System") is a statistical software suite developed by SAS Institute for data management, advanced analytics, multivariate analysis, business intelligence, criminal investigation,and predictive analytics.
+        docs: http://documentation.sas.com/doc/en/sasstudiocdc/3.8/webeditorcdc/sasstudioov/aboutthedoc.htm#n1gj63gr3kst82n1k2uulv8jwcdg
+        env: { "CONN_STRING": "SASStudio" }
+        services:
+          sas-studio: 38080
     name: UNC Restarting Research
   heal:
     extends:

--- a/tycho/context.py
+++ b/tycho/context.py
@@ -201,6 +201,8 @@ class TychoContext:
         principal_params_json = json.dumps(principal_params, indent=4)
         spec["services"][app_id]["securityContext"] = self.apps[app_id]["securityContext"] if 'securityContext' in self.apps[app_id].keys() else None
         spec["services"][app_id].update(resource_request)
+        conn_string = self.apps.get(app_id).get("conn_string", "")
+        spec["services"][app_id]["conn_string"] = conn_string
         if spec is not None:
             system = self._start ({
                 "name"       : app_id,

--- a/tycho/kube.py
+++ b/tycho/kube.py
@@ -239,7 +239,8 @@ class KubernetesCompute(Compute):
             result = {
                 'name'       : system.name,
                 'sid'        : system.identifier,
-                'containers' : container_map
+                'containers' : container_map,
+                'conn_string': system.conn_string
             }
         
         except Exception as e:

--- a/tycho/model.py
+++ b/tycho/model.py
@@ -119,7 +119,7 @@ class Container:
 
 class System:
     """ Distributed system of interacting containerized software. """
-    def __init__(self, config, name, principal, serviceAccount, containers, services={}):
+    def __init__(self, config, name, principal, serviceAccount, conn_string, containers, services={}):
         """ Construct a new abstract model of a system given a name and set of containers.
         
             Serves as context for the generation of compute cluster specific artifacts.
@@ -163,6 +163,7 @@ class System:
         self.namespace = "default"
         self.serviceaccount = serviceAccount
         self.runasroot = os.environ.get("RUNASROOT", "true").lower()
+        self.conn_string = conn_string
         """PVC flags and other variables for default volumes"""
         self.create_home_dirs = os.environ.get("CREATE_HOME_DIRS", "false").lower()
         self.stdnfs_pvc = os.environ.get("STDNFS_PVC", "stdnfs")
@@ -294,6 +295,7 @@ class System:
             "name"       : name,
             "principal"   : principal,
             "serviceAccount": serviceAccount,
+            "conn_string": spec.get("conn_string", ""),
             "containers" : containers
         }
         system_specification['services'] = services

--- a/tycho/template/service.yaml
+++ b/tycho/template/service.yaml
@@ -8,6 +8,7 @@ metadata:
     executor: tycho
     tycho-app: {{ system.name }}
     tycho-guid: {{ system.identifier }}
+    conn_string: {{ system.conn_string }}
   name: {{ service.name }}
   {% if system.amb %}
   annotations: 
@@ -17,14 +18,14 @@ metadata:
       kind:  Mapping
       name: {{system.name}}-mapping
       #host: helx-app.amb-helx-dev.renci.org
-      prefix: /private/{{system.system_name}}/{{system.username}}/{{system.identifier}}/
+      prefix: /private/{{system.system_name}}/{{system.username}}/{{system.identifier}}/{{system.conn_string}}
       service: {{system.name}}:{{system.system_port}}
       {% if system.dev_phase != 'dev' %}
       headers:
           REMOTE_USER: {{system.username}}
       {% endif %}
-      {% if system.system_name == 'jupyter-ds' or system.system_name == 'blackbalsam' or system.system_name == 'hail' or system.system_name == 'blackbalsam-clinical' %}
-      rewrite: /private/{{system.system_name}}/{{system.username}}/{{system.identifier}}/
+      {% if system.system_name == 'jupyter-ds' or system.system_name == 'blackbalsam' or system.system_name == 'hail' or system.system_name == 'blackbalsam-clinical' or system.system_name == 'sas-studio' %}
+      rewrite: /private/{{system.system_name}}/{{system.username}}/{{system.identifier}}/{{system.conn_string}}
       {% endif %}
       bypass_auth: true
       timeout_ms: 300000

--- a/tycho/test/test_client.py
+++ b/tycho/test/test_client.py
@@ -23,7 +23,8 @@ def test_client_start (mocker, system_request, client, request):
                     "ip_address": "127.0.0.1",
                     "port-1": 32661
                 }
-            }
+            },
+            "conn_string": "",
         },
         "message": "Started system jupyter-ds-caa94baea8a849d89e427bd78cad17eb"
     }

--- a/tycho/test/test_model.py
+++ b/tycho/test/test_model.py
@@ -13,6 +13,7 @@ def test_system_model (request):
         "name"       : "test",
         "principal"   : {"username": "renci"},
         "serviceAccount": "default",
+        "conn_string": "",
         "containers" : [
             {
                 "name"  : "nginx-container",


### PR DESCRIPTION
Revert merge [PR-96](https://github.com/helxplatform/tycho/pull/96#issue-623760526) - Separate SAS and patch deployment code.

SAS changes,

Included SAS app in the restartr project context.
SAS app would require an additional string "SASStudio" appended to the URI. For this, added a "connection string" which can be passed from the app configuration defined in Tycho app-registry.
