### PR TITLE
Status api optimize

### DIFF
--- a/bin/tycho-functional-tests
+++ b/bin/tycho-functional-tests
@@ -50,7 +50,7 @@ tycho status
 hits=0
 minikube_ip=$(minikube ip)
 echo --testing $instances instances at $minikube_ip ...
-for p in $(tycho status | grep $test_tag | grep -v PORT | awk '{ print $4 }'); do
+for p in $(kubectl get svc | grep $test_tag | awk '{ print $1 }' | xargs kubectl get svc -o jsonpath='{.spec.ports[].nodePort}'); do
     failed=1
     for cycle in $(seq 1 $max_cycles); do
         echo --testing http://$minikube_ip:$p cycle: $cycle

--- a/tycho/kube.py
+++ b/tycho/kube.py
@@ -402,52 +402,55 @@ class KubernetesCompute(Compute):
             :type name: str
             :param namespace: Namespace the system runs in.
             :type namespace: str
-        """            
+        """
         namespace = self.namespace
         result = []
+
         """ Find all our generated deployments. """
         label = f"tycho-guid={name}" if name else f"executor=tycho"
         if username:
             label = f"username={username}" if username else f"executor=tycho"
-        logger.debug (f"-- status label: {label}")                
+        logger.debug (f"-- status label: {label}")
         response = self.extensions_api.list_namespaced_deployment (
             namespace,
             label_selector=label)
+
         if response is not None:
             for item in response.items:
-                
+
                 """ Collect pod metrics for this deployment. """
                 pod_resources = {
                     container.name : container.resources.limits
                     for container in item.spec.template.spec.containers
                 }
                 logger.debug(f"-- pod-resources {pod_resources}")
-                
+
                 item_guid = item.metadata.labels.get ("tycho-guid", None)
 
-                """Get the workspace name of the pod"""
+                """ Get the creation timestamp"""
+                c_time = item.metadata.creation_timestamp
+                time = f"{c_time.month}-{c_time.day}-{c_time.year} {c_time.hour}:{c_time.minute}:{c_time.second}"
+
+                """ Get the workspace name of the pod """
                 workspace_name = item.spec.template.metadata.labels.get("app-name", "")
 
-                """ List all services with this guid. """
-                services = self.api.list_namespaced_service(
-                    label_selector=f"tycho-guid={item_guid}",
-                    namespace=namespace)
-                """ Inspect and report each service connected to this element separately. """
-                for service in services.items:
-                    c_time = service.metadata.creation_timestamp
-                    time = f"{c_time.month}-{c_time.day}-{c_time.year} {c_time.hour}:{c_time.minute}:{c_time.second}"
-                    ip_address = self.get_service_ip_address (service)
-                    port = service.spec.ports[0].node_port
-                    result.append ({
-                        "name"          : service.metadata.name,
-                        "app_id"        : service.metadata.labels.get ('tycho-app', None),
-                        "sid"           : item_guid,
-                        "ip_address"    : ip_address,
-                        "port"          : str(port),
-                        "creation_time" : time,
-                        "utilization"   : pod_resources,
+                """ Temporary variables so rest of the code doesn't break elsewhere. """
+                ip_address = "127.0.0.1"
+                port = 80
+
+                result.append(
+                    {
+                        "name": item.metadata.name,
+                        "app_id": item.spec.template.metadata.labels.get('app-name', None),
+                        "sid": item_guid,
+                        "ip_address": ip_address,
+                        "port": str(port),
+                        "creation_time": time,
+                        "utilization": pod_resources,
                         "workspace_name": workspace_name
-                    })
+                    }
+                )
+
         return result
 
     def modify(self, system_modify):


### PR DESCRIPTION
Changes made to optimize the tycho status API,

- removed the list kubernetes APIs call to fetch the services of a users. A call to fetch all the deployments of user would give us all the information required by upstream.

There are few other places which can improve but not computationally expensive. For instance, this [line](https://github.com/helxplatform/appstore/blob/b2cb2bf88c5fbca95534611737fdf78c5afb7bac/appstore/api/v1/views.py#L282) is necessary.