### PR TITLE
Rewrite rule

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -16,6 +16,7 @@ def test_system_model(request):
         "principal": {"username": "renci"},
         "service_account": "default",
         "conn_string": "",
+        "proxy_rewrite_rule": False,
         "containers": [
             {
                 "name": "nginx-container",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,7 +14,7 @@ def test_system_model(request):
         "config": Config(),
         "name": "test",
         "principal": {"username": "renci"},
-        "serviceAccount": "default",
+        "service_account": "default",
         "conn_string": "",
         "containers": [
             {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -49,7 +49,7 @@ def test_system_parser(request):
             name="jupyter-ds",
             principal='{"username": "renci"}',
             system=structure,
-            serviceAccount="default")
+            service_account="default")
 
         print(f"{system}")
         assert system.name.startswith('jupyter-ds')

--- a/tycho/__init__.py
+++ b/tycho/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.dev2"
+__version__ = "1.1.dev3"

--- a/tycho/conf/app-registry.yaml
+++ b/tycho/conf/app-registry.yaml
@@ -65,6 +65,7 @@ contexts:
         docs: https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-datascience-notebook
         services:
           jupyter-ds : "8888"
+        proxy-rewrite-rule: True
       filebrowser:
         name: File Browser
         description: File Browser - a utility for browsing files through a web interface
@@ -135,6 +136,7 @@ contexts:
         docs: https://github.com/helxplatform/helx-hail # TODO: Make proper docs.
         services:
           hail : 8000
+        proxy-rewrite-rule: True
       cloud-top:
         name: Cloud Top
         spec: ${catalyst_apps}/cloud-top/docker-compose.yaml
@@ -167,6 +169,7 @@ contexts:
         docs: https://systemsgenetics.github.io/GSForge/
         services:
           gsforge : 8888
+        proxy-rewrite-rule: True
       cloud-top:
         name: Cloud Top
         spec: ${catalyst_apps}/cloud-top/docker-compose.yaml
@@ -189,6 +192,7 @@ contexts:
         serviceAccount: spark
         services:
           blackbalsam : 8888
+        proxy-rewrite-rule: True
       #rshiny:
       #  name: R Shiny
       #  description: Shiny is an R package that makes it easy to build interactive web apps straight from R.
@@ -210,6 +214,7 @@ contexts:
         serviceAccount: spark
         services:
           blackbalsam-clinical : 8888
+        proxy-rewrite-rule: True
       sas-studio:
         name: SAS Studio
         description: Jump-start your data and analytics efforts with an interactive development environment.
@@ -218,6 +223,7 @@ contexts:
         env: { "CONN_STRING": "SASStudio" }
         services:
           sas-studio: 38080
+        proxy-rewrite-rule: True
     name: UNC Restarting Research
   heal:
     extends:
@@ -233,6 +239,7 @@ contexts:
         docs: https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-datascience-notebook
         services:
           jupyter-education: "8888"
+        proxy-rewrite-rule: True
       filebrowser:
         name: File Browser
         description: File Browser - a utility for browsing files through a web interface

--- a/tycho/core.py
+++ b/tycho/core.py
@@ -52,7 +52,7 @@ class Tycho:
             name=request['name'],
             principal=request.get('principal'),
             system=request['system'],
-            serviceAccount=request.get('serviceaccount', 'default'),
+            service_account=request.get('serviceaccount', 'default'),
             env=request.get ('env', {}),
             services=request.get ('services', {}))
 

--- a/tycho/model.py
+++ b/tycho/model.py
@@ -305,7 +305,7 @@ class System:
             })
         system_specification = {"config": config, "name": name, "principal": principal,
                                 "service_account": service_account, "conn_string": spec.get("conn_string", ""),
-                                "proxy_rewrite_rule": spec.get("proxy_rewrite_rule"), "containers": containers,
+                                "proxy_rewrite_rule": spec.get("proxy_rewrite_rule", False), "containers": containers,
                                 'services': services}
         logger.debug (f"parsed-system: {json.dumps(system_specification, indent=2)}")
         system = System(**system_specification)

--- a/tycho/model.py
+++ b/tycho/model.py
@@ -119,7 +119,7 @@ class Container:
 
 class System:
     """ Distributed system of interacting containerized software. """
-    def __init__(self, config, name, principal, serviceAccount, conn_string, containers, services={}):
+    def __init__(self, config, name, principal, service_account, conn_string, proxy_rewrite_rule, containers, services={}):
         """ Construct a new abstract model of a system given a name and set of containers.
         
             Serves as context for the generation of compute cluster specific artifacts.
@@ -162,7 +162,7 @@ class System:
         self.username = principal.get("username")
         self.annotations = {}
         self.namespace = "default"
-        self.serviceaccount = serviceAccount
+        self.serviceaccount = service_account
         self.runasroot = os.environ.get("RUNASROOT", "true").lower()
         self.conn_string = conn_string
         """PVC flags and other variables for default volumes"""
@@ -178,6 +178,8 @@ class System:
         """Resources and limits for the init container"""
         self.init_cpus = os.environ.get("INIT_CPUS", "250m")
         self.init_memory = os.environ.get("INIT_MEMORY", "250Mi")
+        """Proxy rewrite rule for ambassador service annotations"""
+        self.proxy_rewrite_rule = proxy_rewrite_rule
 
     def _get_ambassador_id(self):
         return os.environ.get("AMBASSADOR_ID", "")
@@ -213,7 +215,7 @@ class System:
         return template
 
     @staticmethod
-    def parse (config, name, principal, system, serviceAccount, env={}, services={}):
+    def parse (config, name, principal, system, service_account, env={}, services={}):
         """ Construct a system model based on the input request.
 
             Parses a docker-compose spec into a system specification.
@@ -288,28 +290,23 @@ class System:
             env_from_spec = (spec.get('env', []) or spec.get('environment', []))
             env_from_registry = [f"{ev}={os.environ.get('STDNFS_PVC')}" if '$STDNFS' in env[ev] else f"{ev}={env[ev]}" for ev in env]
             env_all = env_from_spec + env_from_registry
-            containers.append ({
-                "name"    : cname,
-                "image"   : spec['image'],
-                "command" : entrypoint,
-                "env"     : env_all,
-                "limits"  : spec.get ('deploy',{}).get('resources',{}).get('limits',{}),
-                "requests"  : spec.get ('deploy',{}).get('resources',{}).get('reservations',{}),
-                "ports"   : ports,
-                "expose"  : expose,
+            containers.append({
+                "name": cname,
+                "image": spec['image'],
+                "command": entrypoint,
+                "env": env_all,
+                "limits": spec.get('deploy',{}).get('resources',{}).get('limits',{}),
+                "requests": spec.get('deploy',{}).get('resources',{}).get('reservations',{}),
+                "ports": ports,
+                "expose": expose,
                 "depends_on": spec.get("depends_on", []),
-                "volumes"  : [ v for v in spec.get("volumes", []) ],
-                "securityContext" :  spec.get("securityContext", {})
+                "volumes": [v for v in spec.get("volumes", [])],
+                "securityContext":  spec.get("securityContext", {})
             })
-        system_specification = {
-            "config"     : config,
-            "name"       : name,
-            "principal"   : principal,
-            "serviceAccount": serviceAccount,
-            "conn_string": spec.get("conn_string", ""),
-            "containers" : containers
-        }
-        system_specification['services'] = services
+        system_specification = {"config": config, "name": name, "principal": principal,
+                                "service_account": service_account, "conn_string": spec.get("conn_string", ""),
+                                "proxy_rewrite_rule": spec.get("proxy_rewrite_rule"), "containers": containers,
+                                'services': services}
         logger.debug (f"parsed-system: {json.dumps(system_specification, indent=2)}")
         system = System(**system_specification)
         system.source_text = yaml.dump (system)

--- a/tycho/template/service.yaml
+++ b/tycho/template/service.yaml
@@ -26,7 +26,7 @@ metadata:
       headers:
           REMOTE_USER: {{system.username}}
       {% endif %}
-      {% if system.system_name == 'jupyter-ds' or system.system_name == 'blackbalsam' or system.system_name == 'hail' or system.system_name == 'blackbalsam-clinical' or system.system_name == 'sas-studio' or system.system_name == 'gsforge' or system.system_name == 'jupyter-education' %}
+      {% if system.proxy_rewrite_rule == True %}
       rewrite: /private/{{system.system_name}}/{{system.username}}/{{system.identifier}}/{{system.conn_string}}
       {% endif %}
       bypass_auth: true


### PR DESCRIPTION
,Some apps like jupyter notebooks have to be configured to run on a custom URL that appstore generates using a setting called baseURL.
The ambassador proxy has to forward the traffic to the baseURL specified for the app, to achieve we include a re-write rule to the ambassador annotations for each app.

Changes made,

Whichever app require the rewrite-rule are hardcoded in the jinja2 pod template and not desirable. Instead, we define a value (proxy-rewrite-rule: True/False) in the app-registry to let tycho know if a certain app requires a rewrite-rule.

