### PR TITLE
Don't explicitly delete services 

### DIFF
--- a/tycho/kube.py
+++ b/tycho/kube.py
@@ -353,19 +353,6 @@ class KubernetesCompute(Compute):
         """
         namespace = self.namespace #self.get_namespace()
         try: 
-            """ todo: kubectl delete pv,pvc,deployment,pod,svc,networkpolicy -l executor=tycho """
-            """ Delete the service. No obvious collection based api for service deletion. """
-            service_list = self.api.list_namespaced_service(
-                label_selector=f"tycho-guid={name}",
-                namespace=namespace)
-            for service in service_list.items:
-                if service.metadata.labels.get ("tycho-guid", None) == name:
-                    logger.debug (f" --deleting service {name} in namespace {namespace}")
-                    response = self.api.delete_namespaced_service(
-                        name=service.metadata.name,
-                        body={},
-                        namespace=namespace)
-            
             """ Treat everything with a namespace parameterized collections based delete 
             operator the same. """
             finalizers = {


### PR DESCRIPTION
Owner child relationship will catch services when the deployment is deleted