### PR TITLE
Update Jenkinsfile for Jenkins upgrade.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,23 +2,43 @@ pipeline {
     agent {
         kubernetes {
             cloud 'kubernetes'
-            label 'agent-docker'
-            defaultContainer 'agent-docker'
+            yaml '''
+              apiVersion: v1
+              kind: Pod
+              spec:
+                containers:
+                - name: agent-docker
+                  image: helxplatform/agent-docker:latest
+                  command: 
+                  - cat
+                  tty: true
+                  volumeMounts:
+                    - name: dockersock
+                      mountPath: "/var/run/docker.sock"
+                volumes:
+                - name: dockersock
+                  hostPath:
+                    path: /var/run/docker.sock 
+            '''
         }
     }
     stages {
         stage('Install') {
             steps {
-                sh '''
-                make install
-                '''
+	        container('agent-docker') {
+                    sh '''
+                    make install
+                    '''
+                }
             }
         }
         stage('Test') {
             steps {
-                sh '''
-                make test
-                '''
+                container('agent-docker') {
+                    sh '''
+                    make test
+                    '''
+                }
             }
         }
         stage('Publish') {
@@ -29,10 +49,12 @@ pipeline {
                 DOCKERHUB_CREDS = credentials('rencibuild_dockerhub_machine_user')
             }
             steps {
-                sh '''
-                echo $DOCKERHUB_CREDS_PSW | docker login -u $DOCKERHUB_CREDS_USR --password-stdin
-                make publish
-                '''
+                container('agent-docker') {
+                    sh '''
+                    echo $DOCKERHUB_CREDS_PSW | docker login -u $DOCKERHUB_CREDS_USR --password-stdin
+                    make publish
+                    '''
+                }
             }
         }
     }


### PR DESCRIPTION
The upgrade of Jenkins2 requires a change in how Jenkinsfiles are written. In a nutshell, the Podtemplate is moved to the Jenkinsfile and container('<podtemplatename>'){} wraps each step.