### PR TITLE
Add username to properties of TychoService

### DIFF
--- a/tycho/client.py
+++ b/tycho/client.py
@@ -30,13 +30,14 @@ class TychoService:
     """ Represent a service endpoint. """
     try_minikube = True
 
-    def __init__(self, name, app_id, ip_address, port, sid=None, creation_time=None, utilization={}, conn_string="", workspace_name=""):
+    def __init__(self, name, app_id, ip_address, port, sid=None, creation_time=None, username="",utilization={}, conn_string="", workspace_name=""):
         self.name = name
         self.app_id = app_id
         self.ip_address = ip_address
         self.port = port
         self.identifier = sid
         self.creation_time = creation_time
+        self.username = username
         self.utilization = utilization
         self.total_util = self.get_utilization (utilization)
         self.conn_string = conn_string
@@ -65,7 +66,7 @@ class TychoService:
 
     def __repr__(self):
         b = f"id: {self.identifier} time: {self.creation_time} util: {self.utilization}"
-        return f"name: {self.name} ip: {self.ip_address} port: {self.port} {b}"
+        return f"name: {self.name} ip: {self.ip_address} port: {self.port} user:{self.username} {b}"
 
 
 class TychoStatus:

--- a/tycho/kube.py
+++ b/tycho/kube.py
@@ -411,7 +411,8 @@ class KubernetesCompute(Compute):
                 }
                 logger.debug(f"-- pod-resources {pod_resources}")
 
-                item_guid = item.metadata.labels.get ("tycho-guid", None)
+                item_guid = item.metadata.labels.get("tycho-guid", None)
+                item_username = item.metadata.labels.get("username", None)
 
                 """ Get the creation timestamp"""
                 c_time = item.metadata.creation_timestamp
@@ -432,6 +433,7 @@ class KubernetesCompute(Compute):
                         "ip_address": ip_address,
                         "port": str(port),
                         "creation_time": time,
+                        "username": item_username,
                         "utilization": pod_resources,
                         "workspace_name": workspace_name
                     }


### PR DESCRIPTION
Include username tag in the **TychoService** class.  This enables `tycho.status()` to return username as well which can be used to match queries from users and disallow information or alteration of services that do not correspond to that user.