### PR TITLE
Fix all warnings when running tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def get_sample_spec(name):
     d = os.path.dirname(__file__)
     sample_path = os.path.join(d, "../tycho", "sample", name, "docker-compose.yaml")
     with open(sample_path, "r") as stream:
-        result = yaml.load(stream)
+        result = yaml.load(stream, Loader=yaml.FullLoader)
     return result
 
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -2,3 +2,5 @@
 mock_traceback_monkeypatch = false
 log_format = %(asctime)s %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
+markers =
+    kubernetes

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -44,7 +44,7 @@ def test_system_parser(request):
     base_dir = os.path.dirname(os.path.dirname(__file__))
     spec_path = os.path.join(base_dir, "tycho", "sample", "jupyter-ds", "docker-compose.yaml")
     with open(spec_path, "r") as stream:
-        structure = yaml.load(stream)
+        structure = yaml.load(stream, Loader=yaml.FullLoader)
         system = System.parse(
             config=Config(),
             name="jupyter-ds",

--- a/tycho/actions.py
+++ b/tycho/actions.py
@@ -26,7 +26,7 @@ schema_file_path = os.path.join (
     'api-schema.yaml')
 template = None
 with open(schema_file_path, 'r') as file_obj:
-    template = yaml.load(file_obj)
+    template = yaml.load(file_obj, Loader=yaml.FullLoader)
 
 backplane = None
 _tycho = Tycho(backplane=backplane)
@@ -46,7 +46,7 @@ class TychoResource:
         """ Validate a request against the schema. """
         if not self.specs:
             with open(schema_file_path, 'r') as file_obj:
-                self.specs = yaml.load(file_obj)
+                self.specs = yaml.load(file_obj, Loader=yaml.FullLoader)
         to_validate = self.specs["components"]["schemas"][component]
         try:
             logger.debug(f"--:Validating obj {request}")

--- a/tycho/api.py
+++ b/tycho/api.py
@@ -38,7 +38,7 @@ schema_file_path = os.path.join (
     'api-schema.yaml')
 template = None
 with open(schema_file_path, 'r') as file_obj:
-    template = yaml.load(file_obj)
+    template = yaml.load(file_obj, Loader=yaml.FullLoader)
 
 """ Describe the API. """
 app.config['SWAGGER'] = {
@@ -73,7 +73,7 @@ class TychoResource(Resource):
         """ Validate a request against the schema. """
         if not self.specs:
             with open(schema_file_path, 'r') as file_obj:
-                self.specs = yaml.load(file_obj)
+                self.specs = yaml.load(file_obj, Loader=yaml.FullLoader)
         to_validate = self.specs["components"]["schemas"][component]
         try:
             app.logger.debug (f"--:Validating obj {json.dumps(request.json, indent=2)}")

--- a/tycho/model.py
+++ b/tycho/model.py
@@ -53,8 +53,8 @@ class Volumes:
                    volume_name = parts[1].split("/")[2:3][0]
                    pvc_name = volume_name if volume_name not in self.pvcs else None
                    self.pvcs.append(volume_name)
-                   path = parts[2] if len(parts) is 3 else None
-                   subpath = "/".join(parts[1].split("/")[3:]) if len(parts) is 3 else None
+                   path = parts[2] if len(parts) == 3 else None
+                   subpath = "/".join(parts[1].split("/")[3:]) if len(parts) == 3 else None
                    self.volume(container['name'], pvc_name, volume_name, path, subpath)
                else:
                    logger.debug(f"Volume definition should follow the pattern: pvc://<pvc_name>/<sub-path>:<container-path> or pvc://<sub-path>:<container-path>")

--- a/tycho/tycho_utils.py
+++ b/tycho/tycho_utils.py
@@ -59,7 +59,7 @@ class TemplateUtils:
         template.globals['now'] = datetime.datetime.utcnow
         text = template.render (**context)
         logger.debug (text)
-        return yaml.load_all (text)
+        return yaml.load_all (text, Loader=yaml.SafeLoader)
 
     @staticmethod
     def apply_environment (environment, text):


### PR DESCRIPTION
Most warnings were fixed by specifying a Loader for the `yaml.load()` method, which is deprecated when using it without a specific loader because the default loader is unsafe. I kept the default loader (FullLoader) for all except one case, where I'm not sure we can trust the input of the yaml we are getting, so I used SafeLoader in that case.