### PR TITLE
fixes for creating home and shared directories in init.  variable ren…

### DIFF
--- a/tycho/model.py
+++ b/tycho/model.py
@@ -198,7 +198,7 @@ class System:
         self.annotations = {}
         self.namespace = "default"
         self.serviceaccount = service_account
-        self.enable_volume_permissions_init_container = enable_init_container
+        self.enable_init_container = enable_init_container
         self.conn_string = conn_string
         """PVC flags and other variables for default volumes"""
         self.create_home_dirs = os.environ.get("CREATE_HOME_DIRS", "false").lower()
@@ -213,14 +213,14 @@ class System:
         """Override container security context"""
         self.security_context = security_context
         """Resources and limits for the init container"""
-        self.init_cpus = os.environ.get("INIT_CPUS", "250m")
-        self.init_memory = os.environ.get("INIT_MEMORY", "250Mi")
+        self.init_cpus = os.environ.get("TYCHO_APP_INIT_CPUS", "250m")
+        self.init_memory = os.environ.get("TYCHO_APP_INIT_MEMORY", "250Mi")
         """Proxy rewrite rule for ambassador service annotations"""
         self.proxy_rewrite_rule = proxy_rewrite_rule
     @staticmethod
     def enable_init_container(security_context):
         required_keys = ["run_as_user", "run_as_group"]
-        if os.environ.get("TYCHO_APP_ENABLE_VOLUME_PERMISSIONS_INIT_CONTAINER", "false").lower() == "true":
+        if os.environ.get("TYCHO_APP_ENABLE_INIT_CONTAINER", "false").lower() == "true":
             for key in required_keys:
                 if key in security_context.keys() and security_context[key]:
                     continue
@@ -231,15 +231,15 @@ class System:
     @staticmethod
     def set_security_context(sc_from_registry):
         security_context: dict[str, Any] = {}
-        if os.environ.get("RUN_AS_USER"):
+        if os.environ.get("TYCHO_APP_RUN_AS_USER"):
             security_context["run_as_user"] = os.environ.get("TYCHO_APP_RUN_AS_USER")
         else:
             security_context["run_as_user"] = sc_from_registry.get("runAsUser")
-        if os.environ.get("RUN_AS_GROUP"):
+        if os.environ.get("TYCHO_APP_RUN_AS_GROUP"):
             security_context["run_as_group"] = os.environ.get("TYCHO_APP_RUN_AS_GROUP")
         else:
             security_context["run_as_group"] = sc_from_registry.get("runAsGroup")
-        if os.environ.get("FS_GROUP"):
+        if os.environ.get("TYCHO_APP_FS_GROUP"):
             security_context["fs_group"] = os.environ.get("TYCHO_APP_FS_GROUP")
         else:
             security_context["fs_group"] = sc_from_registry.get("fsGroup")

--- a/tycho/template/pod.yaml
+++ b/tycho/template/pod.yaml
@@ -33,13 +33,21 @@ spec:
     effect: "NoSchedule"
   {% endif %}
   {% endif %}
-  {% if system.security_context.fs_group %}
+  {% if system.security_context.run_as_user or system.security_context.run_as_group or system.security_context.fs_group %}
   securityContext:
+    {% if system.security_context.run_as_user %}
+    runAsUser: {{ system.security_context.run_as_user }}
+    {% endif %}
+    {% if system.security_context.run_as_group %}
+    runAsGroup: {{ system.security_context.run_as_group }}
+    {% endif %}
+    {% if system.security_context.fs_group %}
     fsGroup: {{ system.security_context.fs_group }}
+    {% endif %}
   {% endif %}
-{% if (system.enable_volume_permissions_init_container == "true") and (system.create_home_dirs == "true") and (system.dev_phase != "test") %}
+{% if (system.enable_init_container == "true") and (system.create_home_dirs == "true") and (system.dev_phase != "test") %}
   initContainers:
-  - name: volume-permissions
+  - name: volume-tasks
     image: busybox:1.28
     # Fixed resources
     resources:
@@ -49,14 +57,11 @@ spec:
       limits:
         memory: {{ system.init_memory }}
         cpu: {{ system.init_cpus }}
-    {% if system.security_context.run_as_user and system.security_context.run_as_group %}
     command: [ 'sh', '-c' ]
     args:
       - mkdir -p {{ system.parent_dir }}/{{ system.subpath_dir }} &&
         mkdir -p {{ system.parent_dir }}/{{ system.shared_dir }} &&
-        ls -al {{ system.parent_dir }} &&
         echo OK
-    {% endif %}
     volumeMounts:
     - name: {{ system.stdnfs_pvc }}
       mountPath: {{ system.parent_dir }}
@@ -66,15 +71,6 @@ spec:
 {% for container in system.containers %}    
   - name: {{ container.name }}
     image: {{ container.image }}
-    {% if system.security_context %}
-    securityContext:
-      {% if system.security_context.run_as_user %}
-      runAsUser: {{ system.security_context.run_as_user }}
-      {% endif %}
-      {% if system.security_context.run_as_group %}
-      runAsGroup: {{ system.security_context.run_as_group }}
-      {% endif %}
-    {% endif %}
 {% if container.command %}
     command: {{ container.command }}
 {% endif %}


### PR DESCRIPTION
moved securitycontext so it would reside over init and regular containers.  renamed some variables.  enabling the init container and enabling the home dirs creation is a bit redundant since that is all that is done in the init container.  maybe add more tasks later, if not should remove one of the variables.