### PR TITLE
Feat/add pypi automation

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,27 +1,27 @@
-name: "Dependabot Automerge - Action"
+# name: "Dependabot Automerge - Action"
 
-on:
-  pull_request:
+# on:
+#   pull_request:
 
-jobs:
-  worker:
-    runs-on: ubuntu-latest
+# jobs:
+#   worker:
+#     runs-on: ubuntu-latest
 
-    if: github.actor == 'dependabot[bot]' || github.actor == 'cnbennett3'
-    steps:
-      - name: automerge
-        uses: actions/github-script@0.2.0
-        with:
-          script: |
-            github.pullRequests.createReview({
-              owner: context.payload.repository.owner.login,
-              repo: context.payload.repository.name,
-              pull_number: context.payload.pull_request.number,
-              event: 'APPROVE'
-            })
-            github.pullRequests.merge({
-              owner: context.payload.repository.owner.login,
-              repo: context.payload.repository.name,
-              pull_number: context.payload.pull_request.number
-            })
-          github-token: ${{github.token}}
+#     if: github.actor == 'dependabot[bot]' || github.actor == 'cnbennett3'
+#     steps:
+#       - name: automerge
+#         uses: actions/github-script@0.2.0
+#         with:
+#           script: |
+#             github.pullRequests.createReview({
+#               owner: context.payload.repository.owner.login,
+#               repo: context.payload.repository.name,
+#               pull_number: context.payload.pull_request.number,
+#               event: 'APPROVE'
+#             })
+#             github.pullRequests.merge({
+#               owner: context.payload.repository.owner.login,
+#               repo: context.payload.repository.name,
+#               pull_number: context.payload.pull_request.number
+#             })
+#           github-token: ${{github.token}}

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -9,8 +9,6 @@ on:
     tags:
       - v1.*
       - v2.*
-  pull_request:
-    branches: [ master, develop, main ]
 jobs:
   build-deploy-to-pypi:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -1,0 +1,33 @@
+name: upload-pypi
+run-name: Package and Upload to Pypi  
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - main
+    tags:
+      - v1.*
+      - v2.*
+  pull_request:
+    branches: [ master, develop, main ]
+jobs:
+  build-deploy-to-pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install Package Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build
+          python -m pip install --upgrade twine
+      - name: Build Package
+        run: python -m build
+      - name: Publish Package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/upload-to-testpypi.yml
+++ b/.github/workflows/upload-to-testpypi.yml
@@ -1,0 +1,32 @@
+name: upload-testpypi
+run-name: Package and Upload to TestPypi  
+on:
+  push:
+    branches:
+      - feat/*
+      - fix/*
+      - test/*
+      - doc/*
+  pull_request:
+    branches: [ master, develop, main ]
+jobs:
+  build-deploy-to-test-pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install Package Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build
+          python -m pip install --upgrade twine
+      - name: Build Package
+        run: python -m build
+      - name: Publish Package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
I commented out legacy .github/workflows (dependabot and linter) until I can review further and add safe logic if needed. 

Proposed workflow for pypi uploads, all push to [main, master, develop] will result in a pypi release being pushed. Additionally any semver tags v1 or v2 will cause pypi upload. We can tweak as needed, if the preference is to only push to pypi upon push to master/ or tag v1* ? (Please let me know)

All pushes to branches starting with [ feat/* , fix/* , test/*,  doc/* ] will be built and uploaded to Test-Pypi, as well as pull requests from branch to [master, main, develop]