### PR TITLE
Upgrade pyyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask-RESTful==0.3.9
 Jinja2==3.0.3 
 MarkupSafe==2.0.1 
 PyJWT==2.3.0 
-PyYAML==5.4.1
+PyYAML==6.0.1
 Werkzeug==2.0.3 
 adal==1.2.7 
 aniso8601==9.0.1 


### PR DESCRIPTION
The previous version of pyyaml is not compatible with cython 3.0. A more recent release 6.0.1 fixes this issue. 

Pyyaml 6.0.1 change logs: https://github.com/yaml/pyyaml/commit/c42fa3bff1eabdb64763bb1526d9ea1ccb708479

https://stackoverflow.com/a/76710304
