### PR TITLE
add feature to specify the init container image and tag

### DIFF
--- a/tycho/model.py
+++ b/tycho/model.py
@@ -236,6 +236,8 @@ class System:
         """init security context"""
         self.init_security_context = init_security_context
         """Resources and limits for the init container"""
+        self.init_image_repository = os.environ.get("TYCHO_APP_INIT_IMAGE_REPOSITORY", "busybox")
+        self.init_image_tag = os.environ.get("TYCHO_APP_INIT_IMAGE_TAG", "latest")
         self.init_cpus = os.environ.get("TYCHO_APP_INIT_CPUS", "250m")
         self.init_memory = os.environ.get("TYCHO_APP_INIT_MEMORY", "250Mi")
         self.gpu_resource_name = os.environ.get("TYCHO_APP_GPU_RESOURCE_NAME", "nvidia.com/gpu")

--- a/tycho/template/pod.yaml
+++ b/tycho/template/pod.yaml
@@ -48,7 +48,7 @@ spec:
 {% if (system.enable_init_container == "true") and (system.create_home_dirs == "true") and (system.dev_phase != "test") %}
   initContainers:
   - name: volume-tasks
-    image: busybox:1.28
+    image: {{ system.init_image_repository }}:{{ system.init_image_tag }}
     {% if system.init_security_context.run_as_user or system.init_security_context.run_as_group %}
     securityContext:
       {% if system.init_security_context.run_as_user %}


### PR DESCRIPTION
Can set the init image repo and tag (busybox:latest) with env variables.  This goes along with changes for the appstore chart.